### PR TITLE
Filter out null events after preprocessing

### DIFF
--- a/CX3_shared.mjs
+++ b/CX3_shared.mjs
@@ -78,7 +78,10 @@ const regularizeEvents = ({ eventPool, config }) => {
   }
 
   if (typeof config.preProcessor === 'function') {
-    temp = temp.map(config.preProcessor).filter(ev => ev != null)
+    // Apply custom preprocessing function to each event
+    temp = temp.map(config.preProcessor)
+    // Remove any null/undefined events that may have been filtered out by the preprocessor
+    temp = temp.filter(ev => ev != null)
   }
   //rollback
   return temp.map((ev) => {

--- a/CX3_shared.mjs
+++ b/CX3_shared.mjs
@@ -78,7 +78,7 @@ const regularizeEvents = ({ eventPool, config }) => {
   }
 
   if (typeof config.preProcessor === 'function') {
-    temp = temp.map(config.preProcessor)
+    temp = temp.map(config.preProcessor).filter(ev => ev != null)
   }
   //rollback
   return temp.map((ev) => {


### PR DESCRIPTION
Whenever the preProcessor returns null, no events were drawn anymore. By filtering out the null events, and only returning the real ones, everything works.

So I used the preProcessor (tweaked) from the README
```javascript
preProcessor: (ev) => {
	if (ev.title.includes('Focus')) return null
	return ev
}
``` 

Result:

<img width="633" height="214" alt="Image" src="https://github.com/user-attachments/assets/cfb27323-d5c0-46ae-977b-805ee7c8acb1" />

And the following error in the Dev Console:

<img width="614" height="934" alt="Image" src="https://github.com/user-attachments/assets/b69ea14f-7c61-4839-bd49-a55a213d9483" />

After fix:
<img width="383" height="90" alt="image" src="https://github.com/user-attachments/assets/1eb22770-1bfc-4397-9210-306cda95f37b" />
